### PR TITLE
Fix wrong URLs in manifest.json

### DIFF
--- a/custom_components/ha_home_maintenance/const.py
+++ b/custom_components/ha_home_maintenance/const.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 DOMAIN = "ha_home_maintenance"
 NAME = "Home Maintenance Pro"
-VERSION = "1.3.0"
+VERSION = "1.3.1"
 
 # Panel constants
 PANEL_URL = "/api/panel_custom/ha_home_maintenance"

--- a/custom_components/ha_home_maintenance/manifest.json
+++ b/custom_components/ha_home_maintenance/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "ha_home_maintenance",
   "name": "Home Maintenance Pro",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "codeowners": [],
   "config_flow": true,
   "dependencies": ["http", "panel_custom", "tag"],
-  "documentation": "https://github.com/TS24/ha-home-maintenance",
+  "documentation": "https://github.com/TomSelander/ha-home-maintenance",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/TS24/ha-home-maintenance/issues",
+  "issue_tracker": "https://github.com/TomSelander/ha-home-maintenance/issues",
   "requirements": []
 }


### PR DESCRIPTION
## Summary
- Fix documentation and issue_tracker URLs pointing to TS24 instead of TomSelander
- Bump version to 1.3.1

Fixes #2

## Test plan
- [x] Verify URLs in manifest.json resolve correctly
- [x] Verify version consistency across manifest.json, const.py, and const.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)