### PR TITLE
Add button entities for task completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Track recurring home maintenance tasks with a beautiful sidebar panel built righ
 - **Label support** — assign Home Assistant labels to tasks and view them in a dedicated column
 - **Overdue notifications** — enable a per-task toggle to receive a persistent notification automatically when a task becomes overdue
 - **Binary sensors for overdue detection** — one sensor per task and one global "any overdue" sensor for use in automations and dashboards
+- **Button entities** — one 'Complete' button per task for use on dashboards
 - **NFC tag support** — scan an NFC tag to instantly mark a task complete
 - **Configurable sidebar** — choose a custom panel title and optionally restrict access to admins only
 - **Integration icon** — branded icon displayed in the Home Assistant integrations page
@@ -164,6 +165,23 @@ Each task has a **Notify when overdue** toggle on the create/edit form. When ena
    ```
 
 3. Scanning the tag will mark the task complete immediately.
+
+---
+
+## Button Entities
+
+Each task exposes a `button` entity named **"\<Task Title\> Complete"**. Pressing the button marks the task as completed (sets last performed to today), identical to clicking the checkmark in the sidebar panel.
+
+Button entities are automatically created when tasks are added and become unavailable when tasks are deleted. They can be placed on any Home Assistant dashboard using the standard **Button card**.
+
+### Example Dashboard Card
+
+```yaml
+type: button
+entity: button.replace_hvac_filter_complete
+name: Mark HVAC Filter Done
+icon: mdi:check-circle
+```
 
 ---
 

--- a/custom_components/ha_home_maintenance/__init__.py
+++ b/custom_components/ha_home_maintenance/__init__.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.components import frontend
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.util import dt as dt_util
-
-_LOGGER = logging.getLogger(__name__)
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-
-from homeassistant.components import frontend
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_ADMIN_ONLY,
@@ -25,7 +22,9 @@ from .panel import async_register_panel
 from .store import TaskStore
 from .websocket import async_register_websockets
 
-PLATFORMS = ["binary_sensor"]
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = ["binary_sensor", "button"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:

--- a/custom_components/ha_home_maintenance/button.py
+++ b/custom_components/ha_home_maintenance/button.py
@@ -1,0 +1,85 @@
+"""Button platform for the Home Maintenance integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, NAME, VERSION
+from .store import HomeMaintenanceTask, TaskStore
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up button entities from a config entry."""
+    store: TaskStore = hass.data[DOMAIN]["store"]
+    entities = [
+        HomeMaintenanceCompleteButton(store, task, entry)
+        for task in store.get_all_tasks()
+    ]
+    async_add_entities(entities)
+
+    current_task_ids = {task.id for task in store.get_all_tasks()}
+
+    def _on_store_change() -> None:
+        new_tasks = store.get_all_tasks()
+        new_ids = {t.id for t in new_tasks}
+        added = [
+            HomeMaintenanceCompleteButton(store, t, entry)
+            for t in new_tasks
+            if t.id not in current_task_ids
+        ]
+        if added:
+            async_add_entities(added)
+        current_task_ids.clear()
+        current_task_ids.update(new_ids)
+
+    store.add_listener(_on_store_change)
+    entry.async_on_unload(lambda: store.remove_listener(_on_store_change))
+
+
+class HomeMaintenanceCompleteButton(ButtonEntity):
+    """Button that marks a maintenance task as completed."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        store: TaskStore,
+        task: HomeMaintenanceTask,
+        entry: ConfigEntry,
+    ) -> None:
+        self._store = store
+        self._task_id = task.id
+        self._entry = entry
+        self._attr_unique_id = f"{DOMAIN}_{task.id}_complete"
+        self._attr_name = f"{task.title} Complete"
+        self._attr_icon = "mdi:check-circle"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info to link this entity to the integration device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=NAME,
+            manufacturer="Home Maintenance Pro",
+            sw_version=VERSION,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the underlying task still exists."""
+        return self._store.get_task(self._task_id) is not None
+
+    async def async_press(self) -> None:
+        """Handle the button press — mark the task as completed."""
+        await self._store.async_complete_task(self._task_id)

--- a/custom_components/ha_home_maintenance/const.py
+++ b/custom_components/ha_home_maintenance/const.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 DOMAIN = "ha_home_maintenance"
 NAME = "Home Maintenance Pro"
-VERSION = "1.3.1"
+VERSION = "1.4.0"
 
 # Panel constants
 PANEL_URL = "/api/panel_custom/ha_home_maintenance"

--- a/custom_components/ha_home_maintenance/manifest.json
+++ b/custom_components/ha_home_maintenance/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ha_home_maintenance",
   "name": "Home Maintenance Pro",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "codeowners": [],
   "config_flow": true,
   "dependencies": ["http", "panel_custom", "tag"],

--- a/custom_components/ha_home_maintenance/panel/src/const.ts
+++ b/custom_components/ha_home_maintenance/panel/src/const.ts
@@ -1,2 +1,2 @@
-export const VERSION = "1.3.1";
+export const VERSION = "1.4.0";
 export const DOMAIN = "ha_home_maintenance";


### PR DESCRIPTION
## Summary
- Add button platform with one 'Complete' button entity per maintenance task
- Pressing the button marks the task as completed (same as panel checkmark)
- Button entities can be placed on any HA dashboard
- Dynamic entity creation/removal when tasks are added/deleted

Fixes #5

## Test plan
- [ ] Button entities appear for each task after integration reload
- [ ] Pressing a button entity marks the task as completed
- [ ] New tasks get button entities automatically
- [ ] Deleted tasks' button entities become unavailable
- [ ] Button entities show on the integration device

🤖 Generated with [Claude Code](https://claude.com/claude-code)