### PR TITLE
feat: add GitHub Actions release workflow (closes #16)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Package integration
+        run: |
+          zip -r ha_home_maintenance.zip custom_components/ha_home_maintenance \
+            --exclude "custom_components/ha_home_maintenance/panel/node_modules/*" \
+            --exclude "custom_components/ha_home_maintenance/__pycache__/*" \
+            --exclude "custom_components/ha_home_maintenance/panel/src/*" \
+            --exclude "custom_components/ha_home_maintenance/panel/localize/*" \
+            --exclude "custom_components/ha_home_maintenance/panel/build.mjs" \
+            --exclude "custom_components/ha_home_maintenance/panel/package*.json"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ha_home_maintenance.zip
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Package integration
         run: |
@@ -27,7 +27,7 @@ jobs:
             --exclude "custom_components/ha_home_maintenance/panel/package*.json"
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           files: ha_home_maintenance.zip
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` that triggers on `v*.*.*` tag pushes
- Packages `custom_components/ha_home_maintenance/` into `ha_home_maintenance.zip` (excluding source files and node_modules)
- Creates a GitHub release with auto-generated release notes and the zip as a downloadable asset
- Uses `softprops/action-gh-release@v2` with the built-in `GITHUB_TOKEN` — no extra secrets needed

## Closes

Closes #16

## Test plan

- [ ] Push a `v1.5.4` tag to publish the first release: `git tag v1.5.4 && git push origin v1.5.4`
- [ ] Verify the Actions workflow runs and completes successfully
- [ ] Verify a GitHub release is created with `ha_home_maintenance.zip` attached
- [ ] Install via HACS and confirm version selection UI appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)